### PR TITLE
Security patch

### DIFF
--- a/src/Ratchet/Wamp/WampConnection.php
+++ b/src/Ratchet/Wamp/WampConnection.php
@@ -17,7 +17,7 @@ class WampConnection extends AbstractConnectionDecorator {
         parent::__construct($conn);
 
         $this->WAMP            = new \StdClass;
-        $this->WAMP->sessionId = str_replace('.', '', uniqid(mt_rand(), true));
+        $this->WAMP->sessionId = bin2hex(random_bytes(32));
         $this->WAMP->prefixes  = array();
 
         $this->send(json_encode(array(WAMP::MSG_WELCOME, $this->WAMP->sessionId, 1, \Ratchet\VERSION)));


### PR DESCRIPTION
Swapped the usage of ``mt_rand`` and ``uniqid`` for a secure alternative that provides session-ids of an increased length and cryptographic security (32 bytes should be 64 characters in length).
See [this](https://huntr.dev/bounties/b1b59d6f-35ca-40cf-a572-486f901ccb64) and [this](https://huntr.dev/bounties/e9fc7371-2251-4a4e-80d2-f154793f10ce).